### PR TITLE
Create a method to retrieve all the cards in all hardware generations.

### DIFF
--- a/DeviceInfoUtils.cpp
+++ b/DeviceInfoUtils.cpp
@@ -626,6 +626,17 @@ bool AMDTDeviceInfoUtils::GetHardwareGeneration(const char* szName, GDT_HW_GENER
     }
 }
 
+void AMDTDeviceInfoUtils::GetAllCards(std::vector<GDT_GfxCardInfo>& cardList) const
+{
+    cardList.clear();
+    cardList.reserve(gs_cardInfoSize);
+
+    for(size_t i = 0ULL; i < gs_cardInfoSize; ++i)
+    {
+        cardList.push_back(gs_cardInfo[i]);
+    }
+}
+
 bool AMDTDeviceInfoUtils::GetAllCardsInHardwareGeneration(GDT_HW_GENERATION gen, std::vector<GDT_GfxCardInfo>& cardList) const
 {
     cardList.clear();

--- a/DeviceInfoUtils.h
+++ b/DeviceInfoUtils.h
@@ -108,6 +108,10 @@ public:
     /// \return True if device info is found
     bool GetHardwareGeneration(const char* szCALDeviceName, GDT_HW_GENERATION& gen) const;
 
+    /// Get all cards in all hardware generations.
+    /// \param[out] cardList Output vector of all graphics card info.
+    void GetAllCards(std::vector<GDT_GfxCardInfo>& cardList) const;
+
     /// Get all cards from the specified hardware generation
     /// \param[in] gen Hardware generation
     /// \param[out] cardList Output vector of graphics card info.


### PR DESCRIPTION
This method is necessary to get RGA working on non-AMD hardware.